### PR TITLE
✨ fix: セレクトボックスで表示する値を、狙ったテーブルの狙った値を表示できる用に変更

### DIFF
--- a/dayrepo/snippets/forms.py
+++ b/dayrepo/snippets/forms.py
@@ -1,13 +1,18 @@
 from django import forms
-from .models import Snippet
+from .models import Snippet, Car
 from django.core.exceptions import NON_FIELD_ERRORS
 
 
+class CustomSnippetModelChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj): # label_from_instance 関数をオーバーライド
+         return obj.vehicle_number # 表示したいカラム名を return
 
 class SnippetForm(forms.ModelForm):
+    car_id = CustomSnippetModelChoiceField(queryset=Car.objects.all())
     class Meta:
         #モデルを指定
         model = Snippet
+        
         #フォームとして表示したいカラムを指定
         fields = (
             'account_id',
@@ -30,24 +35,24 @@ class SnippetForm(forms.ModelForm):
             'free_space',
             )
         widgets = {
-            'account_id':forms.Select(
-                choices=(
-                ('','アカウントを選択'),
-                ('0','gokki'),
-                ('1','やんけ'),
-                ('2','とっしー'),
-                ),
-                attrs={
-                'required' : 'アカウントを選択'
-            }),
-            'account_id':forms.Select(
-                choices=(
-                ('','車両を選択'),
-                ('0','札幌 ひ 20-20'),
-                ('1','船橋 ふ 19-19'),
-                ('2','八雲 や 89-89'),
-                ),
-                attrs={
-                'required' : '車両を選択'
-            }),
+            # 'account_id':forms.Select(
+            #     choices=(
+            #     ('','アカウントを選択'),
+            #     ('0','gokki'),
+            #     ('1','やんけ'),
+            #     ('2','とっしー'),
+            #     ),
+            #     attrs={
+            #     'required' : 'アカウントを選択'
+            # }),
+            # 'account_id':forms.Select(
+            #     choices=(
+            #     ('','車両を選択'),
+            #     ('札幌 ひ 20-20','0'),
+            #     ('1','船橋 ふ 19-19'),
+            #     ('2','八雲 や 89-89'),
+            #     ),
+            #     attrs={
+            #     'required' : '車両を選択'
+            # }),
         }

--- a/dayrepo/snippets/forms.py
+++ b/dayrepo/snippets/forms.py
@@ -34,25 +34,4 @@ class SnippetForm(forms.ModelForm):
             'break_time',
             'free_space',
             )
-        widgets = {
-            # 'account_id':forms.Select(
-            #     choices=(
-            #     ('','アカウントを選択'),
-            #     ('0','gokki'),
-            #     ('1','やんけ'),
-            #     ('2','とっしー'),
-            #     ),
-            #     attrs={
-            #     'required' : 'アカウントを選択'
-            # }),
-            # 'account_id':forms.Select(
-            #     choices=(
-            #     ('','車両を選択'),
-            #     ('札幌 ひ 20-20','0'),
-            #     ('1','船橋 ふ 19-19'),
-            #     ('2','八雲 や 89-89'),
-            #     ),
-            #     attrs={
-            #     'required' : '車両を選択'
-            # }),
-        }
+        widgets = {}

--- a/dayrepo/snippets/forms.py
+++ b/dayrepo/snippets/forms.py
@@ -8,7 +8,7 @@ class CustomSnippetModelChoiceField(forms.ModelChoiceField):
          return obj.vehicle_number # 表示したいカラム名を return
 
 class SnippetForm(forms.ModelForm):
-    car_id = CustomSnippetModelChoiceField(queryset=Car.objects.all())
+    car_id = CustomSnippetModelChoiceField(queryset=Car.objects.all(), empty_label="車両番号を選択してください")
     class Meta:
         #モデルを指定
         model = Snippet


### PR DESCRIPTION
## 概要
- (コミットメッセージが切れちゃった😭)
- 表題ままです。

## 動作確認
<img width="1008" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/d4686369-d4c6-4673-986d-14d294007e36">

また、デフォルトで option タグの value には pk が入ります。以下を参考にすると変更も可能です。
https://docs.djangoproject.com/en/5.0/ref/forms/fields/#django.forms.ModelChoiceField.to_field_name


## ポイント
- ModelChoiceField を利用すること
- label_from_instance メソッドをオーバーライドすること
の2点です。

## 参考サイト
- [公式ドキュメント ModelChoiceField](https://docs.djangoproject.com/en/5.0/ref/forms/fields/#modelchoicefield)
- [Django の ModelForm でプルダウンをテーブルから取得する](https://notemite.com/django/django-modelform-select-option-from-db/)
- [ModelChoiceFieldで__str__は変更せず、表示する文字列を変更する](https://qiita.com/myname6c7c2/items/f21b040d64443456fefd)

## 補足
まず、とりあえずフォームに関するところなのはわかっていたので、公式ドキュメントのここまでは普通にググって辿り着きました。
https://docs.djangoproject.com/en/5.0/ref/forms/fields/#module-django.forms.fields

このサイトを全部読むのは辛いので、とりあえず「セレクト」を検索をかけるとこれらが引っかかりました、
<img width="854" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/621f2137-21bb-49fb-b513-fb4a644e953a">
以下箇条書き
- FilePathField
- MultipleChoiceField
- NullBooleanField
- TypedChoiceField
- TypedMultipleChoiceField
- ModelChoiceField
- ModelMultipleChoiceField

それらを翻訳しながら眺めていると、とっても怪しいのがみつ見つかりました。
<img width="867" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/b514c993-9bd5-40e6-aad3-6e6c4ebdf304">

> [ModelChoiceField](https://docs.djangoproject.com/en/5.0/ref/forms/fields/#django.forms.ModelChoiceField)モデル間の関係を表すために、と の 2 つのフィールドを使用できます[ModelMultipleChoiceField](https://docs.djangoproject.com/en/5.0/ref/forms/fields/#django.forms.ModelMultipleChoiceField)。これらのフィールドはどちらも、querysetフィールドの選択肢を作成するために使用される 1 つのパラメーターを必要とします。

選択肢を作成するために使用される 1 つのパラメーター....?おやおや？みたいな感じです。


まず[以下にあるように](https://docs.djangoproject.com/en/5.0/ref/forms/fields/#modelchoicefield)、この ModelChoiceField は class Select をデフォルトで利用しています。Select を利用するところまでは一緒でした。
<img width="445" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/6ee6fb05-198e-4367-87b8-87e84ba91a0a">

class Select: https://docs.djangoproject.com/en/5.0/ref/forms/widgets/#django.forms.Select

#### 一番決定的だった項目は以下
<img width="820" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/e576a079-b98d-4bd7-b131-45067e9af8de">

> モデルのメソッド__str__()が呼び出され、フィールドの選択で使用するオブジェクトの文字列表現が生成されます。カスタマイズされた表現を提供するには、 をサブクラス化ModelChoiceFieldし、 をオーバーライドします

この部分です。
ここを読み、試しに以下を self.id から self.vehicle_number に変更してみました。
<img width="411" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/1c56e867-8f51-4428-979f-d15d7848415f">
すると、これだけでも車両番号を描画することに成功したため、 __str__ メソッドを利用した値が入ることを理解しました。
<img width="1018" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/1c860cb5-a165-49d9-b70b-f6b92fad9837">

そして後は公式ドキュメントの通り、「カスタマイズされた表現を提供するには、 をサブクラス化ModelChoiceFieldし、 をオーバーライドします」なので、label_from_instance メソッドをオーバーライドするため、 ここでいくつかググった情報( 参考サイトにある2つなど )を参考に return を何パターンか試したらうまくいった。といった感じです。

