### PR TITLE
🐛 debug: snippets アプリのパスを変更した際に、不要な / を入れてしまっていたので削除

### DIFF
--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path("car/", views.pre_car_registration,name="pre_car_registration"),
     path("car/new/", views.car_registration,name="car_registration"),
     path("employee/", views.get_employee,name="get_employee"),
-    path("/", views.snippet_list,name="snippet_list"),
+    path("", views.snippet_list,name="snippet_list"),
     path("post/", views.snippet_post,name="snippet_post"),
     path("checklist/", views.checklist_post,name="checklist_post"),
 ]


### PR DESCRIPTION
## 概要
- タイトルまま
- 以下の修正でバグったため、修正しましたmm

- 結論、ルートのパスを指定するときに / はいらないみたいです。

## 動作確認
<img width="545" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/3e9c95f5-59e5-499b-91c8-c0a1a54fce1a">



## 参考URL
- [【Django】urls.py：ルーティングの書き方（urlpatterns、path、include）](https://office54.net/python/django/urls-path-include#google_vignette)
  - <img width="428" alt="image" src="https://github.com/bob-g12/dayrepo-for-transportation/assets/62760395/544b8677-6c50-4cff-a8fe-2e446d2931a9">
