### PR TITLE
投稿データの削除機能作成

### DIFF
--- a/dayrepo/snippets/templates/snippet_list.html
+++ b/dayrepo/snippets/templates/snippet_list.html
@@ -6,9 +6,10 @@
     <p id="checklist">{{ checklist }}</p>
     <button onclick="location.href='{% url 'checklist_edit' checklist.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_post' checklist.id %}'">snippet作成</button>
-    <form method="post" action={% url 'db_delete' checklist.id 'checklist' %}>
+    <form method="post" action="{% url 'db_delete' checklist.id 'checklist' %}">
         {% csrf_token %}
         <button type="submit">点検削除</button>
+    </form>
     <hr>
     {% endfor %}
     <h2>提出済み日報一覧</h2>

--- a/dayrepo/snippets/templates/snippet_list.html
+++ b/dayrepo/snippets/templates/snippet_list.html
@@ -6,7 +6,9 @@
     <p id="checklist">{{ checklist }}</p>
     <button onclick="location.href='{% url 'checklist_edit' checklist.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_post' checklist.id %}'">snippet作成</button>
-    <button onclick="location.href='{% url 'post_delete' checklist.id 'checklist' %}'">点検削除</button>
+    <form method="post" action={% url 'post_delete' checklist.id 'checklist' %}>
+        {% csrf_token %}
+        <button type="submit">点検削除</button>
     <hr>
     {% endfor %}
     <h2>提出済み日報一覧</h2>
@@ -15,8 +17,12 @@
     <button onclick="location.href='{% url 'excelfile_download' post.id %}'">出力</button>
     <button onclick="location.href='{% url 'checklist_edit' post.checklist_id.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_edit' post.id %}'">日報編集</button>
-    <button onclick="location.href='{% url 'post_delete' post.id 'snippet' %}'">日報削除</button>
-    <button onclick="location.href='{% url 'post_delete' post.id 'all' %}'">一括削除</button>
+    <form method="post" action={% url 'post_delete' post.id 'snippet' %}>
+        {% csrf_token %}
+        <button type="submit">日報削除</button>
+    <form method="post" action={% url 'post_delete' post.id 'all' %}>
+        {% csrf_token %}
+        <button type="submit">一括削除</button>
     <hr>
     {% endfor %}
 {% endblock %}

--- a/dayrepo/snippets/templates/snippet_list.html
+++ b/dayrepo/snippets/templates/snippet_list.html
@@ -6,7 +6,7 @@
     <p id="checklist">{{ checklist }}</p>
     <button onclick="location.href='{% url 'checklist_edit' checklist.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_post' checklist.id %}'">snippet作成</button>
-    <form method="post" action={% url 'post_delete' checklist.id 'checklist' %}>
+    <form method="post" action={% url 'db_delete' checklist.id 'checklist' %}>
         {% csrf_token %}
         <button type="submit">点検削除</button>
     <hr>
@@ -17,10 +17,10 @@
     <button onclick="location.href='{% url 'excelfile_download' post.id %}'">出力</button>
     <button onclick="location.href='{% url 'checklist_edit' post.checklist_id.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_edit' post.id %}'">日報編集</button>
-    <form method="post" action={% url 'post_delete' post.id 'snippet' %}>
+    <form method="post" action={% url 'db_delete' post.id 'snippet' %}>
         {% csrf_token %}
         <button type="submit">日報削除</button>
-    <form method="post" action={% url 'post_delete' post.id 'all' %}>
+    <form method="post" action={% url 'db_delete' post.id 'all' %}>
         {% csrf_token %}
         <button type="submit">一括削除</button>
     <hr>

--- a/dayrepo/snippets/templates/snippet_list.html
+++ b/dayrepo/snippets/templates/snippet_list.html
@@ -18,12 +18,14 @@
     <button onclick="location.href='{% url 'excelfile_download' post.id %}'">出力</button>
     <button onclick="location.href='{% url 'checklist_edit' post.checklist_id.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_edit' post.id %}'">日報編集</button>
-    <form method="post" action={% url 'db_delete' post.id 'snippet' %}>
+    <form method="post" action="{% url 'db_delete' post.id 'snippet' %}">
         {% csrf_token %}
         <button type="submit">日報削除</button>
-    <form method="post" action={% url 'db_delete' post.id 'all' %}>
+    </form>
+    <form method="post" action="{% url 'db_delete' post.id 'all' %}">
         {% csrf_token %}
         <button type="submit">一括削除</button>
+    </form>
     <hr>
     {% endfor %}
 {% endblock %}

--- a/dayrepo/snippets/templates/snippet_list.html
+++ b/dayrepo/snippets/templates/snippet_list.html
@@ -16,7 +16,7 @@
     <button onclick="location.href='{% url 'checklist_edit' post.checklist_id.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_edit' post.id %}'">日報編集</button>
     <button onclick="location.href='{% url 'post_delete' post.id 'snippet' %}'">日報削除</button>
-    <button onclick="location.href='{% url 'post_delete' post.id 'oll' %}'">オール削除</button>
+    <button onclick="location.href='{% url 'post_delete' post.id 'all' %}'">オール削除</button>
     <hr>
     {% endfor %}
 {% endblock %}

--- a/dayrepo/snippets/templates/snippet_list.html
+++ b/dayrepo/snippets/templates/snippet_list.html
@@ -6,6 +6,7 @@
     <p id="checklist">{{ checklist }}</p>
     <button onclick="location.href='{% url 'checklist_edit' checklist.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_post' checklist.id %}'">snippet作成</button>
+    <button onclick="location.href='{% url 'post_delete' checklist.id 'checklist' %}'">点検削除</button>
     <hr>
     {% endfor %}
     <h2>提出済み日報一覧</h2>
@@ -14,6 +15,8 @@
     <button onclick="location.href='{% url 'excelfile_download' post.id %}'">出力</button>
     <button onclick="location.href='{% url 'checklist_edit' post.checklist_id.id %}'">点検編集</button>
     <button onclick="location.href='{% url 'snippet_edit' post.id %}'">日報編集</button>
+    <button onclick="location.href='{% url 'post_delete' post.id 'snippet' %}'">日報削除</button>
+    <button onclick="location.href='{% url 'post_delete' post.id 'oll' %}'">オール削除</button>
     <hr>
     {% endfor %}
 {% endblock %}

--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -14,5 +14,6 @@ urlpatterns = [
     path("checklist/", views.checklist_post,name="checklist_post"),
     path("edit/<int:snippet_id>/", views.snippet_edit,name="snippet_edit"),
     path("edit/checklist/<int:checklist_id>/", views.checklist_edit,name="checklist_edit"),
+    path("delete/<int:post_id>/<str:post_type>/", views.post_delete,name="post_delete"),
     path("excel/<int:snippet_pk>/", views.excelfile_download,name="excelfile_download"),
 ]

--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -14,6 +14,6 @@ urlpatterns = [
     path("checklist/", views.checklist_post,name="checklist_post"),
     path("edit/<int:snippet_id>/", views.snippet_edit,name="snippet_edit"),
     path("edit/checklist/<int:checklist_id>/", views.checklist_edit,name="checklist_edit"),
-    path("delete/<int:target_id>/<str:delete_type>/", views.postdata_delete,name="post_delete"),
+    path("delete/<int:target_id>/<str:delete_type>/", views.delete,name="post_delete"),
     path("excel/<int:snippet_pk>/", views.excelfile_download,name="excelfile_download"),
 ]

--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -14,6 +14,6 @@ urlpatterns = [
     path("checklist/", views.checklist_post,name="checklist_post"),
     path("edit/<int:snippet_id>/", views.snippet_edit,name="snippet_edit"),
     path("edit/checklist/<int:checklist_id>/", views.checklist_edit,name="checklist_edit"),
-    path("delete/<int:target_id>/<str:delete_type>/", views.post_delete,name="post_delete"),
+    path("delete/<int:target_id>/<str:delete_type>/", views.postdata_delete,name="post_delete"),
     path("excel/<int:snippet_pk>/", views.excelfile_download,name="excelfile_download"),
 ]

--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -14,6 +14,6 @@ urlpatterns = [
     path("checklist/", views.checklist_post,name="checklist_post"),
     path("edit/<int:snippet_id>/", views.snippet_edit,name="snippet_edit"),
     path("edit/checklist/<int:checklist_id>/", views.checklist_edit,name="checklist_edit"),
-    path("delete/<int:target_id>/<str:delete_type>/", views.delete,name="post_delete"),
+    path("delete/<int:target_id>/<str:delete_type>/", views.db_delete,name="post_delete"),
     path("excel/<int:snippet_pk>/", views.excelfile_download,name="excelfile_download"),
 ]

--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -14,6 +14,6 @@ urlpatterns = [
     path("checklist/", views.checklist_post,name="checklist_post"),
     path("edit/<int:snippet_id>/", views.snippet_edit,name="snippet_edit"),
     path("edit/checklist/<int:checklist_id>/", views.checklist_edit,name="checklist_edit"),
-    path("delete/<int:target_id>/<str:delete_type>/", views.db_delete,name="post_delete"),
+    path("delete/<int:target_id>/<str:delete_type>/", views.db_delete,name="db_delete"),
     path("excel/<int:snippet_pk>/", views.excelfile_download,name="excelfile_download"),
 ]

--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -14,6 +14,6 @@ urlpatterns = [
     path("checklist/", views.checklist_post,name="checklist_post"),
     path("edit/<int:snippet_id>/", views.snippet_edit,name="snippet_edit"),
     path("edit/checklist/<int:checklist_id>/", views.checklist_edit,name="checklist_edit"),
-    path("delete/<int:post_id>/<str:post_type>/", views.post_delete,name="post_delete"),
+    path("delete/<int:target_id>/<str:delete_type>/", views.post_delete,name="post_delete"),
     path("excel/<int:snippet_pk>/", views.excelfile_download,name="excelfile_download"),
 ]

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -325,7 +325,7 @@ class SnippetEditView(View):
 snippet_edit = SnippetEditView.as_view()
 
 
-class DeletePattern():
+class DbDeletePattern():
     # 対象のsnippetと、
     # snippet_idを取得したdutiestroubleとprocessの削除
     # 更にchecklistのsnippet判定カラムの値をFalseへ
@@ -377,10 +377,10 @@ class DeletePattern():
         snippet.delete()
         checklist.delete()
 
-def delete(request:any, target_id:int, delete_type:str):
+def db_delete(request:any, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
-    del_class = DeletePattern()
+    del_class = DbDeletePattern()
     if delete_type == "snippet":
         del_class.snippet_del(target_id)
         return redirect(to="snippet_list")

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -395,8 +395,8 @@ def db_delete(request:HttpRequest, target_id:int, delete_type:str):
     elif delete_type == "checklist":
         del_pattern.checklist_del(target_id)
     elif delete_type == "all":
-
         del_pattern.all_del(target_id)
+    
     return redirect(to="snippet_list")
 
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -370,15 +370,16 @@ class DbDeletePattern():
         dutiestrouble = DutiesTrouble.objects.get(
             snippet_id=target_id
         )
-        dutiestrouble.delete()
         process_list = get_list_or_404(
             Process, 
             snippet_id=target_id
         )
-        for process in process_list:
-            process.delete()
+        
         snippet.delete()
         checklist.delete()
+        dutiestrouble.delete()
+        for process in process_list:
+            process.delete()
 
 def db_delete(request:HttpRequest, target_id:int, delete_type:str):
     if request.method != 'POST':

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -352,7 +352,7 @@ class DbDeletePattern():
         checklist.is_snippet_make = False
         checklist.save()
 
-    # 未提出postdataのchecklistを削除する
+    # 未提出 data の checklist を削除する
     def checklist_del(self,target_id:int):
         checklist = Checklist.objects.get(
         pk=target_id

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -162,7 +162,6 @@ class SnippetView(View):
 
 snippet_post = SnippetView.as_view()
 
-
 # checklist入力画面表示/POST処理
 class ChecklistView(View):
     # 新規入力画面
@@ -329,7 +328,39 @@ class SnippetEditView(View):
             post_snippet=snippet
             # トップ画面へ
             return redirect(to="snippet_list")
+
 snippet_edit = SnippetEditView.as_view()
+
+class PostDelete(View):
+    def get(self,request,post_id,post_type):
+        if post_type == "snippet":
+            snippet = Snippet.objects.get(pk=post_id)
+            checklist = Checklist.objects.get(pk=snippet.checklist_id.id)
+            checklist.is_snippet_make = False
+            checklist.save()
+            dutiestrouble = DutiesTrouble.objects.get(snippet_id=post_id)
+            dutiestrouble.delete()
+            process = get_list_or_404(Process,snippet_id=post_id)
+            for i in range(len(process)):
+                process[i].delete()
+            snippet.delete()
+            return redirect(to="snippet_list")
+        elif post_type == "checklist":
+            checklist = Checklist.objects.get(pk=post_id)
+            checklist.delete()
+            return redirect(to="snippet_list")
+        elif post_type == "oll":
+            snippet = Snippet.objects.get(pk=post_id)
+            checklist = Checklist.objects.get(pk=snippet.checklist_id.pk)
+            dutiestrouble = DutiesTrouble.objects.get(snippet_id=post_id)
+            dutiestrouble.delete()
+            process = get_list_or_404(Process,snippet_id=post_id)
+            for i in range(len(process)):
+                process[i].delete()
+            snippet.delete()
+            checklist.delete()
+            return redirect(to="snippet_list")
+post_delete = PostDelete.as_view()
 
 def excelfile_download(request, snippet_pk):
     # Excelのテンプレートファイルの読み込み

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -62,6 +62,7 @@ class SnippetListView(View):
 
 snippet_list = SnippetListView.as_view()
 
+
 # snippet画面の表示/POST後処理
 class SnippetView(View):
     # 新規入力画面へ
@@ -75,7 +76,7 @@ class SnippetView(View):
                 "form_trouble": DutiesTroubleForm,
                 "form_process": ProcessForm,
                 "process_count": 1,
-                "checklist_id": checklist_id
+                "checklist_id": checklist_id,
             },
         )
 
@@ -93,7 +94,7 @@ class SnippetView(View):
         if oil == "":
             oil = 0.0
 
-        snippet = Snippet( 
+        snippet = Snippet(
             # 末尾の [0] について
             # 入力項目のうち同一名のデータは、
             # request.POST に配列で記録され、
@@ -162,6 +163,7 @@ class SnippetView(View):
 
 snippet_post = SnippetView.as_view()
 
+
 # checklist入力画面表示/POST処理
 class ChecklistView(View):
     # 新規入力画面
@@ -192,17 +194,16 @@ class ChecklistView(View):
 
         return redirect(to="snippet_list")
 
+
 checklist_post = ChecklistView.as_view()
+
 
 class ChecklistEditView(View):
     def get(self, request, checklist_id):
         checklist = get_object_or_404(Checklist, pk=checklist_id)
         edit_form = ChecklistForm(instance=checklist)
-        return render(
-            request, 
-            "checklist_edit.html",
-              {'form': edit_form}
-        )
+        return render(request, "checklist_edit.html", {"form": edit_form})
+
     def post(self, request, checklist_id):
         post = get_object_or_404(Checklist, pk=checklist_id)
         form = ChecklistForm(request.POST, instance=post)
@@ -210,6 +211,7 @@ class ChecklistEditView(View):
         return redirect(to="snippet_list")
 
 checklist_edit = ChecklistEditView.as_view()
+
 
 class SnippetEditView(View):
     def get(self, request, snippet_id):
@@ -224,149 +226,168 @@ class SnippetEditView(View):
         for i in range(process_len):
             edit_ProcessForm.append(ProcessForm(instance=post_process[i]))
         return render(
-            request, 
-            "snippet_edit.html", 
+            request,
+            "snippet_edit.html",
             {
-                'form': edit_SnippetForm,
-                'form_trouble': edit_TroubleForm,
-                'form_process': edit_ProcessForm,
-                'process_count': process_len,
-                'checklist_id':checklist_id
-            }
+                "form": edit_SnippetForm,
+                "form_trouble": edit_TroubleForm,
+                "form_process": edit_ProcessForm,
+                "process_count": process_len,
+                "checklist_id": checklist_id,
+            },
         )
-    def post(self, request,snippet_id):
-            req = request.POST
-            post_snippet = get_object_or_404(
-                Snippet,
-                pk=snippet_id
-            )
-            post_trouble = get_object_or_404(
-                DutiesTrouble, 
-                snippet_id=snippet_id
-            )
-            post_process = get_list_or_404(
-                Process,
-                snippet_id=snippet_id
-            )
-            checklist_id = post_snippet.checklist_id
-            # スニペットフォーム保存
-            # checklists_id挿入のための
-            # モデルデータ作成
-            gasoline = req.get("gasoline_amount")
-            if gasoline == "":
-                gasoline = 0.0
-            oil = req.get("oil")
-            if oil == "":
-                oil = 0.0
 
-            snippet = Snippet(
-                id = post_snippet.pk,
-                checklist_id=checklist_id,
-                # 末尾の [0] について
-                # 入力項目のうち同一名のデータは、
-                # request.POST に配列で記録され、
-                # snippet においては index[0] を使用する
-                start_time=req.getlist("start_time")[0],
-                end_time=req.getlist("end_time")[0],
-                start_point=req.getlist("start_point")[0],
-                end_point=req.getlist("end_point")[0],
-                start_mileage=req.get("start_mileage"),
-                end_mileage=req.get("end_mileage"),
-                break_spot=req.get("break_spot"),
-                weather=req.get("weather"),
-                gasoline_amount=gasoline,
-                oil=oil,
-                driving_time=req.get("driving_time"),
-                non_driving_time=req.get("non_driving_time"),
-                break_time=req.get("break_time"),
-                is_today_trouble=req.get("is_today_trouble"),
-                free_space=req.get("free_space"),
-                create_at=post_snippet.create_at
+    def post(self, request, snippet_id):
+        req = request.POST
+        post_snippet = get_object_or_404(Snippet, pk=snippet_id)
+        post_trouble = get_object_or_404(DutiesTrouble, snippet_id=snippet_id)
+        post_process = get_list_or_404(Process, snippet_id=snippet_id)
+        checklist_id = post_snippet.checklist_id
+        # スニペットフォーム保存
+        # checklists_id挿入のための
+        # モデルデータ作成
+        gasoline = req.get("gasoline_amount")
+        if gasoline == "":
+            gasoline = 0.0
+        oil = req.get("oil")
+        if oil == "":
+            oil = 0.0
+
+        snippet = Snippet(
+            id=post_snippet.pk,
+            checklist_id=checklist_id,
+            # 末尾の [0] について
+            # 入力項目のうち同一名のデータは、
+            # request.POST に配列で記録され、
+            # snippet においては index[0] を使用する
+            start_time=req.getlist("start_time")[0],
+            end_time=req.getlist("end_time")[0],
+            start_point=req.getlist("start_point")[0],
+            end_point=req.getlist("end_point")[0],
+            start_mileage=req.get("start_mileage"),
+            end_mileage=req.get("end_mileage"),
+            break_spot=req.get("break_spot"),
+            weather=req.get("weather"),
+            gasoline_amount=gasoline,
+            oil=oil,
+            driving_time=req.get("driving_time"),
+            non_driving_time=req.get("non_driving_time"),
+            break_time=req.get("break_time"),
+            is_today_trouble=req.get("is_today_trouble"),
+            free_space=req.get("free_space"),
+            create_at=post_snippet.create_at,
+        )
+        if snippet.is_today_trouble == "on":
+            snippet.is_today_trouble = True
+        else:
+            snippet.is_today_trouble = False
+        snippet.save()
+
+        # 業務トラブルフォーム保存
+        duties_trouble = DutiesTrouble(
+            id=post_trouble.id,
+            snippet_id=post_trouble.snippet_id,
+            trouble_situation=req.get("trouble_situation"),
+            trouble_cause=req.get("trouble_cause"),
+            trouble_support=req.get("trouble_support"),
+        )
+        post_trouble.delete()
+        duties_trouble.save()
+
+        # 工程テーブルフォーム保存
+        form_process_count = len(req.getlist("via_point"))
+        for i in range(form_process_count):
+            process = Process(
+                id=post_process[i].id,
+                snippet_id=post_process[i].snippet_id,
+                start_time=req.getlist("start_time")[i + 1],
+                end_time=req.getlist("end_time")[i + 1],
+                start_point=req.getlist("start_point")[i + 1],
+                end_point=req.getlist("end_point")[i + 1],
+                via_point=req.getlist("via_point")[i],
+                client=req.getlist("client")[i],
+                goods=req.getlist("goods")[i],
+                load_situation=req.getlist("load_situation")[i],
+                load_mileage=req.getlist("load_mileage")[i],
+                hollow_mileage=req.getlist("hollow_mileage")[i],
+                is_load_situation=req.getlist("is_load_situation")[i],
             )
-            if snippet.is_today_trouble == "on":
-                snippet.is_today_trouble = True
+            if process.is_load_situation == "on":
+                process.is_load_situation = True
             else:
-                snippet.is_today_trouble = False
-            snippet.save()
-
-            # 業務トラブルフォーム保存
-            duties_trouble = DutiesTrouble(
-                id=post_trouble.id,
-                snippet_id=post_trouble.snippet_id,
-                trouble_situation=req.get("trouble_situation"),
-                trouble_cause=req.get("trouble_cause"),
-                trouble_support=req.get("trouble_support"),
-            )
-            post_trouble.delete()
-            duties_trouble.save()
-            
-            
-            # 工程テーブルフォーム保存
-            form_process_count = len(req.getlist("via_point"))
-            for i in range(form_process_count):
-                process = Process(
-                    id=post_process[i].id,
-                    snippet_id=post_process[i].snippet_id,
-                    start_time=req.getlist("start_time")[i + 1],
-                    end_time=req.getlist("end_time")[i + 1],
-                    start_point=req.getlist("start_point")[i + 1],
-                    end_point=req.getlist("end_point")[i + 1],
-                    via_point=req.getlist("via_point")[i],
-                    client=req.getlist("client")[i],
-                    goods=req.getlist("goods")[i],
-                    load_situation=req.getlist("load_situation")[i],
-                    load_mileage=req.getlist("load_mileage")[i],
-                    hollow_mileage=req.getlist("hollow_mileage")[i],
-                    is_load_situation=req.getlist("is_load_situation")[i],
-                )
-                if process.is_load_situation == "on":
-                    process.is_load_situation = True
-                else:
-                    process.is_load_situation = False
-                post_process[i].delete()
-                process.save()
-            post_snippet=snippet
-            # トップ画面へ
-            return redirect(to="snippet_list")
+                process.is_load_situation = False
+            post_process[i].delete()
+            process.save()
+        post_snippet = snippet
+        # トップ画面へ
+        return redirect(to="snippet_list")
 
 snippet_edit = SnippetEditView.as_view()
 
-class PostDelete(View):
-    def get(self,request,target_id,delete_type):
-        if delete_type == "snippet":
-            snippet = Snippet.objects.get(pk=target_id)
-            checklist = Checklist.objects.get(pk=snippet.checklist_id.id)
-            checklist.is_snippet_make = False
-            checklist.save()
-            dutiestrouble = DutiesTrouble.objects.get(snippet_id=target_id)
-            dutiestrouble.delete()
-            process = get_list_or_404(Process,snippet_id=target_id)
-            for process_object in process:
-                process_object.delete()
-            snippet.delete()
-            return redirect(to="snippet_list")
-        elif delete_type == "checklist":
-            checklist = Checklist.objects.get(pk=target_id)
-            checklist.delete()
-            return redirect(to="snippet_list")
-        elif delete_type == "all":
-            snippet = Snippet.objects.get(pk=target_id)
-            checklist = Checklist.objects.get(pk=snippet.checklist_id.pk)
-            dutiestrouble = DutiesTrouble.objects.get(snippet_id=target_id)
-            dutiestrouble.delete()
-            process = get_list_or_404(Process,snippet_id=target_id)
-            for process_object in process:
-                process_object.delete()
-            snippet.delete()
-            checklist.delete()
-            return redirect(to="snippet_list")
-post_delete = PostDelete.as_view()
+
+class post_del_pattern():
+    def snippet_del(request,target_id):
+        snippet = Snippet.objects.get(
+            pk=target_id
+        )
+        checklist = Checklist.objects.get(
+            pk=snippet.checklist_id.id
+        )
+        checklist.is_snippet_make = False
+        checklist.save()
+        dutiestrouble = DutiesTrouble.objects.get(
+            snippet_id=target_id
+        )
+        dutiestrouble.delete()
+        process = get_list_or_404(
+            Process, snippet_id=target_id
+        )
+        for process_object in process:
+            process_object.delete()
+        snippet.delete()
+
+    def checklist_del(request,target_id):
+        checklist = Checklist.objects.get(
+        pk=target_id
+        )
+        checklist.delete()
+
+    def all_del(request,target_id):
+        snippet = Snippet.objects.get(
+            pk=target_id
+        )
+        checklist = Checklist.objects.get(
+            pk=snippet.checklist_id.pk
+        )
+        dutiestrouble = DutiesTrouble.objects.get(
+            snippet_id=target_id
+        )
+        dutiestrouble.delete()
+        process = get_list_or_404(
+            Process, 
+            snippet_id=target_id
+        )
+        for process_object in process:
+            process_object.delete()
+        snippet.delete()
+        checklist.delete()
+def post_delete(request, target_id, delete_type):
+    del_class = post_del_pattern()
+    if delete_type == "snippet":
+        del_class.snippet_del(target_id)
+        return redirect(to="snippet_list")
+    elif delete_type == "checklist":
+        del_class.checklist_del(target_id)
+        return redirect(to="snippet_list")
+    elif delete_type == "all":
+        del_class.all_del(target_id)
+        return redirect(to="snippet_list")
+
+
 
 def excelfile_download(request, snippet_pk):
     # Excelのテンプレートファイルの読み込み
-    wb = openpyxl.load_workbook(
-        "./snippets/static/excel/report.xlsx"
-    )
+    wb = openpyxl.load_workbook("./snippets/static/excel/report.xlsx")
     # 入力対象のシート指定
     sheet = wb["report_sheet"]
     # snippetテーブル
@@ -394,7 +415,7 @@ def excelfile_download(request, snippet_pk):
         + str(snippet_data.end_time.minute)
     )
     weekday = snippet_data.checklist_id.working_day.weekday()
-    weeklist = ["月","火","水","木","金","土","日"]
+    weeklist = ["月", "火", "水", "木", "金", "土", "日"]
     week = weeklist[weekday]
     sheet["A3"] = (
         str(snippet_data.checklist_id.working_day.year)
@@ -402,10 +423,11 @@ def excelfile_download(request, snippet_pk):
         + str(snippet_data.checklist_id.working_day.month)
         + " 月  "
         + str(snippet_data.checklist_id.working_day.day)
-        + " 日  " 
+        + " 日  "
         + "( "
         + week
-        + " 曜日)  "+ "天候 "
+        + " 曜日)  "
+        + "天候 "
         + "( "
         + snippet_data.weather
         + " )"
@@ -419,7 +441,8 @@ def excelfile_download(request, snippet_pk):
     sheet["I9"] = snippet_data.start_mileage
     sheet["S9"] = snippet_data.end_mileage
 
-    today_mileage = snippet_data.end_mileage - snippet_data.start_mileage
+    today_mileage = snippet_data.end_mileage 
+    - snippet_data.start_mileage
     if today_mileage >= 0:
         sheet["AB9"] = today_mileage
     if snippet_data.gasoline_amount != False:
@@ -451,18 +474,26 @@ def excelfile_download(request, snippet_pk):
     if work_minute >= 60:
         work_minute -= 60
         work_hour += 1
-    work_hour += snippet_data.driving_time.hour 
-    + snippet_data.non_driving_time.hour
 
-    sheet["BG18"] = str(work_hour) + ":" + str(work_minute)
-    breek_in_minute = work_minute 
-    + snippet_data.break_time.minute
+    work_hour += snippet_data.driving_time.hour
+    +snippet_data.non_driving_time.hour
+
+    sheet["BG18"] = str(work_hour) 
+    + ":" 
+    + str(work_minute)
+
+    breek_in_minute = work_minute
+    +snippet_data.break_time.minute
+
     breek_in_hour = work_hour
     if breek_in_minute >= 60:
         breek_in_minute -= 60
         breek_in_hour += 1
     breek_in_hour += snippet_data.break_time.hour
-    sheet["BI18"] = str(breek_in_hour) + ":" + str(breek_in_minute)
+    sheet["BI18"] = str(breek_in_hour) 
+    + ":" 
+    + str(breek_in_minute)
+
     sheet["BF36"] = snippet_data.free_space
     sheet["H21"] = snippet_data.break_spot
     # チェックリストテーブル
@@ -516,16 +547,83 @@ def excelfile_download(request, snippet_pk):
     process_list = get_list_or_404(Process, snippet_id=snippet_pk)
     process_count = len(process_list)
 
-    process_cell_1 = ["C23","G23","O23","X23","AJ23","AS23","BD23","BG23","BI23"]
-    process_cell_2 = ["C25","G25","O25","X25","AJ25","AS25","BD25","BG25","BI25"]
-    process_cell_3 = ["C27","G27","O27","X27","AJ27","AS27","BD27","BG27","BI27"]
-    process_cell_4 = ["C29","G29","O29","X29","AJ29","AS29","BD29","BG29","BI29"]
-    process_cell_5 = ["C31","G31","O31","X31","AJ31","AS31","BD31","BG31","BI31"]
-    process_cell_6 = ["C33","G33","O33","X33","AJ33","AS33","BD33","BG33","BI33"]
+    process_cell_1 = [
+        "C23",
+        "G23",
+        "O23",
+        "X23",
+        "AJ23",
+        "AS23",
+        "BD23",
+        "BG23",
+        "BI23",
+    ]
+    process_cell_2 = [
+        "C25",
+        "G25",
+        "O25",
+        "X25",
+        "AJ25",
+        "AS25",
+        "BD25",
+        "BG25",
+        "BI25",
+    ]
+    process_cell_3 = [
+        "C27",
+        "G27",
+        "O27",
+        "X27",
+        "AJ27",
+        "AS27",
+        "BD27",
+        "BG27",
+        "BI27",
+    ]
+    process_cell_4 = [
+        "C29",
+        "G29",
+        "O29",
+        "X29",
+        "AJ29",
+        "AS29",
+        "BD29",
+        "BG29",
+        "BI29",
+    ]
+    process_cell_5 = [
+        "C31",
+        "G31",
+        "O31",
+        "X31",
+        "AJ31",
+        "AS31",
+        "BD31",
+        "BG31",
+        "BI31",
+    ]
+    process_cell_6 = [
+        "C33",
+        "G33",
+        "O33",
+        "X33",
+        "AJ33",
+        "AS33",
+        "BD33",
+        "BG33",
+        "BI33",
+    ]
 
-    cell_list = [process_cell_1,process_cell_2,process_cell_3,process_cell_4,process_cell_5,process_cell_6]
+    cell_list = [
+        process_cell_1,
+        process_cell_2,
+        process_cell_3,
+        process_cell_4,
+        process_cell_5,
+        process_cell_6,
+    ]
     for i in range(process_count):
-        process_insert(sheet,process_list[i],cell_list[i])
+        process_insert(sheet, process_list[i], cell_list[i])
 
     # content_typeに、Excelファイル(xlsxファイル)を返すことを表記しています。
     response = HttpResponse(
@@ -536,6 +634,7 @@ def excelfile_download(request, snippet_pk):
     wb.save(response)
     # 生成したHttpResponseをreturnする
     return response
+
 
 # excelfile_download内で工程を入力する関数
 def process_insert(sheet: openpyxl, process: Process, cell_list: list):
@@ -550,4 +649,4 @@ def process_insert(sheet: openpyxl, process: Process, cell_list: list):
     if process.load_mileage != False:
         sheet[cell_list[7]] = process.load_mileage
     if process.hollow_mileage != False:
-       sheet[cell_list[8]] = process.hollow_mileage
+        sheet[cell_list[8]] = process.hollow_mileage

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -326,6 +326,9 @@ snippet_edit = SnippetEditView.as_view()
 
 
 class PostDataDelPattern():
+    # 対象のsnippetと、
+    # snippet_idを取得したdutiestroubleとprocessの削除
+    # 更にchecklistのsnippet判定カラムの値をFalseへ
     def snippet_del(request,target_id):
         snippet = Snippet.objects.get(
             pk=target_id
@@ -346,12 +349,14 @@ class PostDataDelPattern():
             process_object.delete()
         snippet.delete()
 
+    # 未提出postdataのchecklistを削除する
     def checklist_del(request,target_id):
         checklist = Checklist.objects.get(
         pk=target_id
         )
         checklist.delete()
 
+    # 提出済みpostdataをすべて削除する
     def all_del(request,target_id):
         snippet = Snippet.objects.get(
             pk=target_id
@@ -373,6 +378,8 @@ class PostDataDelPattern():
         checklist.delete()
 
 def postdata_delete(request, target_id, delete_type):
+    # 受け取ったdelete_typeから
+    # 削除対象を判別し、実行クラスの処理を選択
     del_class = PostDataDelPattern()
     if delete_type == "snippet":
         del_class.snippet_del(target_id)

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -359,7 +359,7 @@ class DbDeletePattern():
         )
         checklist.delete()
 
-    # 提出済みpostdataをすべて削除する
+    # 提出済み data をすべて削除する
     def all_del(self,target_id:int):
         snippet = Snippet.objects.get(
             pk=target_id

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -329,7 +329,7 @@ class PostDataDelPattern():
     # 対象のsnippetと、
     # snippet_idを取得したdutiestroubleとprocessの削除
     # 更にchecklistのsnippet判定カラムの値をFalseへ
-    def snippet_del(request,target_id):
+    def snippet_del(request:any,target_id:int):
         snippet = Snippet.objects.get(
             pk=target_id
         )
@@ -350,14 +350,14 @@ class PostDataDelPattern():
         snippet.delete()
 
     # 未提出postdataのchecklistを削除する
-    def checklist_del(request,target_id):
+    def checklist_del(request:any,target_id:int):
         checklist = Checklist.objects.get(
         pk=target_id
         )
         checklist.delete()
 
     # 提出済みpostdataをすべて削除する
-    def all_del(request,target_id):
+    def all_del(request:any,target_id:int):
         snippet = Snippet.objects.get(
             pk=target_id
         )
@@ -377,9 +377,10 @@ class PostDataDelPattern():
         snippet.delete()
         checklist.delete()
 
-def postdata_delete(request, target_id, delete_type):
+def postdata_delete(request:any, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
+    print(request)
     del_class = PostDataDelPattern()
     if delete_type == "snippet":
         del_class.snippet_del(target_id)

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -383,13 +383,11 @@ def db_delete(request:any, target_id:int, delete_type:str):
     del_class = DbDeletePattern()
     if delete_type == "snippet":
         del_class.snippet_del(target_id)
-        return redirect(to="snippet_list")
     elif delete_type == "checklist":
         del_class.checklist_del(target_id)
-        return redirect(to="snippet_list")
     elif delete_type == "all":
         del_class.all_del(target_id)
-        return redirect(to="snippet_list")
+    return redirect(to="snippet_list")
 
 
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -325,7 +325,7 @@ class SnippetEditView(View):
 snippet_edit = SnippetEditView.as_view()
 
 
-class PostDataDelPattern():
+class DeletePattern():
     # 対象のsnippetと、
     # snippet_idを取得したdutiestroubleとprocessの削除
     # 更にchecklistのsnippet判定カラムの値をFalseへ
@@ -377,11 +377,11 @@ class PostDataDelPattern():
         snippet.delete()
         checklist.delete()
 
-def postdata_delete(request:any, target_id:int, delete_type:str):
+def delete(request:any, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
     print(request)
-    del_class = PostDataDelPattern()
+    del_class = DeletePattern()
     if delete_type == "snippet":
         del_class.snippet_del(target_id)
         return redirect(to="snippet_list")

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -349,7 +349,7 @@ class PostDelete(View):
             checklist = Checklist.objects.get(pk=post_id)
             checklist.delete()
             return redirect(to="snippet_list")
-        elif post_type == "oll":
+        elif post_type == "all":
             snippet = Snippet.objects.get(pk=post_id)
             checklist = Checklist.objects.get(pk=snippet.checklist_id.pk)
             dutiestrouble = DutiesTrouble.objects.get(snippet_id=post_id)

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -341,8 +341,8 @@ class PostDelete(View):
             dutiestrouble = DutiesTrouble.objects.get(snippet_id=post_id)
             dutiestrouble.delete()
             process = get_list_or_404(Process,snippet_id=post_id)
-            for i in range(len(process)):
-                process[i].delete()
+            for process_object in process:
+                process_object.delete()
             snippet.delete()
             return redirect(to="snippet_list")
         elif post_type == "checklist":
@@ -355,8 +355,8 @@ class PostDelete(View):
             dutiestrouble = DutiesTrouble.objects.get(snippet_id=post_id)
             dutiestrouble.delete()
             process = get_list_or_404(Process,snippet_id=post_id)
-            for i in range(len(process)):
-                process[i].delete()
+            for process_object in process:
+                process_object.delete()
             snippet.delete()
             checklist.delete()
             return redirect(to="snippet_list")

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -332,29 +332,29 @@ class SnippetEditView(View):
 snippet_edit = SnippetEditView.as_view()
 
 class PostDelete(View):
-    def get(self,request,post_id,post_type):
-        if post_type == "snippet":
-            snippet = Snippet.objects.get(pk=post_id)
+    def get(self,request,target_id,delete_type):
+        if delete_type == "snippet":
+            snippet = Snippet.objects.get(pk=target_id)
             checklist = Checklist.objects.get(pk=snippet.checklist_id.id)
             checklist.is_snippet_make = False
             checklist.save()
-            dutiestrouble = DutiesTrouble.objects.get(snippet_id=post_id)
+            dutiestrouble = DutiesTrouble.objects.get(snippet_id=target_id)
             dutiestrouble.delete()
-            process = get_list_or_404(Process,snippet_id=post_id)
+            process = get_list_or_404(Process,snippet_id=target_id)
             for process_object in process:
                 process_object.delete()
             snippet.delete()
             return redirect(to="snippet_list")
-        elif post_type == "checklist":
-            checklist = Checklist.objects.get(pk=post_id)
+        elif delete_type == "checklist":
+            checklist = Checklist.objects.get(pk=target_id)
             checklist.delete()
             return redirect(to="snippet_list")
-        elif post_type == "all":
-            snippet = Snippet.objects.get(pk=post_id)
+        elif delete_type == "all":
+            snippet = Snippet.objects.get(pk=target_id)
             checklist = Checklist.objects.get(pk=snippet.checklist_id.pk)
-            dutiestrouble = DutiesTrouble.objects.get(snippet_id=post_id)
+            dutiestrouble = DutiesTrouble.objects.get(snippet_id=target_id)
             dutiestrouble.delete()
-            process = get_list_or_404(Process,snippet_id=post_id)
+            process = get_list_or_404(Process,snippet_id=target_id)
             for process_object in process:
                 process_object.delete()
             snippet.delete()

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -347,7 +347,7 @@ class DbDeletePattern():
             pk=snippet.checklist_id.id
         )
 
-        # 対象のsnippetが削除されたことを反映し、
+        # 対象のsnippetが削除されたとき、
         # 未提出日報として表示、判定させる
         checklist.is_snippet_make = False
         checklist.save()

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -383,18 +383,18 @@ class DbDeletePattern():
 def db_delete(request:HttpRequest, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
-    del_class = DbDeletePattern()
+    del_pattern = DbDeletePattern()
     if request.method != 'POST':
         raise ValueError(
             "本来入るはずのない処理に入りました。お手数ですが、システムにお問合せください。"
         )
     if delete_type == "snippet":
-        del_class.snippet_del(target_id)
+        del_pattern.snippet_del(target_id)
     elif delete_type == "checklist":
-        del_class.checklist_del(target_id)
+        del_pattern.checklist_del(target_id)
     elif delete_type == "all":
 
-        del_class.all_del(target_id)
+        del_pattern.all_del(target_id)
     return redirect(to="snippet_list")
 
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -331,11 +331,11 @@ class DbDeletePattern():
             snippet_id=target_id
         )
         dutiestrouble.delete()
-        process = get_list_or_404(
+        process_list = get_list_or_404(
             Process, snippet_id=target_id
         )
-        for process_object in process:
-            process_object.delete()
+        for process in process_list:
+            process.delete()
 
         snippet = Snippet.objects.get(
             pk=target_id

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -348,7 +348,7 @@ class DbDeletePattern():
         )
 
         # 対象のsnippetが削除されたことを反映し、
-        # checklistのみの投稿として表示、判定させる
+        # 未提出日報として表示、判定させる
         checklist.is_snippet_make = False
         checklist.save()
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -330,14 +330,6 @@ class DeletePattern():
     # snippet_idを取得したdutiestroubleとprocessの削除
     # 更にchecklistのsnippet判定カラムの値をFalseへ
     def snippet_del(self:any,target_id:int):
-        snippet = Snippet.objects.get(
-            pk=target_id
-        )
-        checklist = Checklist.objects.get(
-            pk=snippet.checklist_id.id
-        )
-        checklist.is_snippet_make = False
-        checklist.save()
         dutiestrouble = DutiesTrouble.objects.get(
             snippet_id=target_id
         )
@@ -347,6 +339,14 @@ class DeletePattern():
         )
         for process_object in process:
             process_object.delete()
+        snippet = Snippet.objects.get(
+            pk=target_id
+        )
+        checklist = Checklist.objects.get(
+            pk=snippet.checklist_id.id
+        )
+        checklist.is_snippet_make = False
+        checklist.save()
         snippet.delete()
 
     # 未提出postdataのchecklistを削除する

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -363,12 +363,12 @@ class PostDataDelPattern():
             snippet_id=target_id
         )
         dutiestrouble.delete()
-        process = get_list_or_404(
+        process_list = get_list_or_404(
             Process, 
             snippet_id=target_id
         )
-        for process_object in process:
-            process_object.delete()
+        for process in process_list:
+            process.delete()
         snippet.delete()
         checklist.delete()
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -389,6 +389,7 @@ def db_delete(request:HttpRequest, target_id:int, delete_type:str):
     elif delete_type == "checklist":
         del_class.checklist_del(target_id)
     elif delete_type == "all":
+
         del_class.all_del(target_id)
     return redirect(to="snippet_list")
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -381,13 +381,14 @@ class DbDeletePattern():
         checklist.delete()
 
 def db_delete(request:HttpRequest, target_id:int, delete_type:str):
-    # 受け取ったdelete_typeから
-    # 削除対象を判別し、実行クラスの処理を選択
-    del_pattern = DbDeletePattern()
     if request.method != 'POST':
         raise ValueError(
             "本来入るはずのない処理に入りました。お手数ですが、システムにお問合せください。"
         )
+
+    # 受け取ったdelete_typeから
+    # 削除対象を判別し、実行クラスの処理を選択
+    del_pattern = DbDeletePattern()
     if delete_type == "snippet":
         del_pattern.snippet_del(target_id)
     elif delete_type == "checklist":

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -326,14 +326,13 @@ snippet_edit = SnippetEditView.as_view()
 
 
 class DbDeletePattern():
-    # 対象のsnippetと、
-    # snippet_idを取得したdutiestroubleとprocessの削除
     def snippet_del(self:any,target_id:int):
+        # snippetと紐づいたdutiestroubleの削除
         dutiestrouble = DutiesTrouble.objects.get(
             snippet_id=target_id
         )
         dutiestrouble.delete()
-
+        # snippetと紐づいたprocessの削除
         process = get_list_or_404(
             Process, snippet_id=target_id
         )
@@ -351,7 +350,7 @@ class DbDeletePattern():
         )
 
         # 対象のsnippetが削除されたことを反映し、
-        # checklistのみの投稿として表示、判定されます
+        # checklistのみの投稿として表示、判定させる
         checklist.is_snippet_make = False
         checklist.save()
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -325,7 +325,7 @@ class SnippetEditView(View):
 snippet_edit = SnippetEditView.as_view()
 
 
-class post_del_pattern():
+class PostDataDelPattern():
     def snippet_del(request,target_id):
         snippet = Snippet.objects.get(
             pk=target_id
@@ -372,8 +372,8 @@ class post_del_pattern():
         snippet.delete()
         checklist.delete()
 
-def post_delete(request, target_id, delete_type):
-    del_class = post_del_pattern()
+def postdata_delete(request, target_id, delete_type):
+    del_class = PostDataDelPattern()
     if delete_type == "snippet":
         del_class.snippet_del(target_id)
         return redirect(to="snippet_list")

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -384,6 +384,10 @@ def db_delete(request:HttpRequest, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
     del_class = DbDeletePattern()
+    if request.method != 'POST':
+        raise ValueError(
+            "本来入るはずのない処理に入りました。お手数ですが、システムにお問合せください。"
+        )
     if delete_type == "snippet":
         del_class.snippet_del(target_id)
     elif delete_type == "checklist":

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -329,7 +329,7 @@ class DeletePattern():
     # 対象のsnippetと、
     # snippet_idを取得したdutiestroubleとprocessの削除
     # 更にchecklistのsnippet判定カラムの値をFalseへ
-    def snippet_del(request:any,target_id:int):
+    def snippet_del(self:any,target_id:int):
         snippet = Snippet.objects.get(
             pk=target_id
         )
@@ -350,14 +350,14 @@ class DeletePattern():
         snippet.delete()
 
     # 未提出postdataのchecklistを削除する
-    def checklist_del(request:any,target_id:int):
+    def checklist_del(self:any,target_id:int):
         checklist = Checklist.objects.get(
         pk=target_id
         )
         checklist.delete()
 
     # 提出済みpostdataをすべて削除する
-    def all_del(request:any,target_id:int):
+    def all_del(self:any,target_id:int):
         snippet = Snippet.objects.get(
             pk=target_id
         )
@@ -380,7 +380,6 @@ class DeletePattern():
 def delete(request:any, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
-    print(request)
     del_class = DeletePattern()
     if delete_type == "snippet":
         del_class.snippet_del(target_id)

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -328,26 +328,32 @@ snippet_edit = SnippetEditView.as_view()
 class DbDeletePattern():
     # 対象のsnippetと、
     # snippet_idを取得したdutiestroubleとprocessの削除
-    # 更にchecklistのsnippet判定カラムの値をFalseへ
     def snippet_del(self:any,target_id:int):
         dutiestrouble = DutiesTrouble.objects.get(
             snippet_id=target_id
         )
         dutiestrouble.delete()
+
         process = get_list_or_404(
             Process, snippet_id=target_id
         )
         for process_object in process:
             process_object.delete()
+
         snippet = Snippet.objects.get(
             pk=target_id
         )
+        snippet.delete()
+
+
         checklist = Checklist.objects.get(
             pk=snippet.checklist_id.id
         )
+
+        # 対象のsnippetが削除されたことを反映し、
+        # checklistのみの投稿として表示、判定されます
         checklist.is_snippet_make = False
         checklist.save()
-        snippet.delete()
 
     # 未提出postdataのchecklistを削除する
     def checklist_del(self:any,target_id:int):

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -355,7 +355,7 @@ class DbDeletePattern():
     # 未提出 data の checklist を削除する
     def checklist_del(self,target_id:int):
         checklist = Checklist.objects.get(
-        pk=target_id
+            pk=target_id
         )
         checklist.delete()
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -371,6 +371,7 @@ class post_del_pattern():
             process_object.delete()
         snippet.delete()
         checklist.delete()
+
 def post_delete(request, target_id, delete_type):
     del_class = post_del_pattern()
     if delete_type == "snippet":

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -326,7 +326,7 @@ snippet_edit = SnippetEditView.as_view()
 
 
 class DbDeletePattern():
-    def snippet_del(self:any,target_id:int):
+    def snippet_del(self,target_id:int):
         # snippetと紐づいたdutiestroubleの削除
         dutiestrouble = DutiesTrouble.objects.get(
             snippet_id=target_id
@@ -355,14 +355,14 @@ class DbDeletePattern():
         checklist.save()
 
     # 未提出postdataのchecklistを削除する
-    def checklist_del(self:any,target_id:int):
+    def checklist_del(self,target_id:int):
         checklist = Checklist.objects.get(
         pk=target_id
         )
         checklist.delete()
 
     # 提出済みpostdataをすべて削除する
-    def all_del(self:any,target_id:int):
+    def all_del(self,target_id:int):
         snippet = Snippet.objects.get(
             pk=target_id
         )
@@ -382,7 +382,7 @@ class DbDeletePattern():
         snippet.delete()
         checklist.delete()
 
-def db_delete(request:any, target_id:int, delete_type:str):
+def db_delete(request:tuple, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
     del_class = DbDeletePattern()

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpRequest
 from django.views.generic import View
 from django.shortcuts import redirect, get_object_or_404, get_list_or_404
 from .models import Account, Car, Snippet, DutiesTrouble, Checklist, Process
@@ -382,7 +382,7 @@ class DbDeletePattern():
         snippet.delete()
         checklist.delete()
 
-def db_delete(request:tuple, target_id:int, delete_type:str):
+def db_delete(request:HttpRequest, target_id:int, delete_type:str):
     # 受け取ったdelete_typeから
     # 削除対象を判別し、実行クラスの処理を選択
     del_class = DbDeletePattern()


### PR DESCRIPTION
# 概要
投稿済みデータの削除機能を作成します
## 見積もり等計画
[こちら](https://github.com/bob-g12/dayrepo-for-transportation/issues/55)のissueにて実行
## 想定動作
- 下記の手順にて確認済み
1. リスト画面に点検削除または、日報、all削除のボタンが表示される
2. 未提出日報一覧の点検削除ボタンを押した場合、点検データが削除される。
3. 提出済み日報一覧のsnippet削除を押した場合、対象のsnippetデータが削除され、残されたchecklistデータが未提出日報一覧に表示される。また、checklistデータの中で相方のsnippetが作成された記録であるis_snippet_makeをTrueからFalseに変える
4. 提出済み日報一覧のoll削除を押した場合、対象のデータをすべて削除する。また、対象を特定するidはsnippetであるため、checklistデータもしっかりと消えているか要確認
![image](https://github.com/bob-g12/dayrepo-for-transportation/assets/126374166/3f963e63-7816-4b43-9a64-a152eb6de352)
![image](https://github.com/bob-g12/dayrepo-for-transportation/assets/126374166/f50e5dda-2744-469b-bc67-5fe23215001f)
## 今後対処するべき状況
- 削除機能が確認やクッションもなく行われてしまうことや、ボタンが増えすぎているため、ダイアログにて確認と削除動作を統括する必要がある。cssが必要であり、類似した設定を同時に行いたいため後に対処予定