### PR TITLE
車両情報の編集機能作成/snippet編集機能の手直し

### DIFF
--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -46,7 +46,7 @@ class CarView(View):
 
 new_car = CarView.as_view()
 
-def serial_number_divide(car: object):
+def serial_number_divide(car: classmethod) -> list:
     if len(str(car.serial_number)) > 2:
         border = len(str(car.serial_number))-2
         str_serial_number = str(car.serial_number)
@@ -55,8 +55,7 @@ def serial_number_divide(car: object):
     else:
         serial_number_top = ""
         serial_number_end = car.serial_number
-    return_list = [serial_number_top,serial_number_end]
-    return return_list
+    return [serial_number_top,serial_number_end]
 
 class CarEditView(View):
     def get(self, request: HttpRequest, car_id: int):

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -49,11 +49,11 @@ def serial_number_divide(car: Car) -> list:
     str_number = str(car.serial_number)
     if len(str_number) > 2:
         border = len(str_number)-2
-        serial_number_top = int(str_number[:border])
-        serial_number_end = int(str_number[border:])
+        serial_number_top = str_number[:border]
+        serial_number_end = str_number[border:]
     else:
         serial_number_top = ""
-        serial_number_end = car.serial_number
+        serial_number_end = str_number
     return [serial_number_top,serial_number_end]
 
 class CarEditView(View):

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -47,11 +47,11 @@ class CarView(View):
 new_car = CarView.as_view()
 
 def serial_number_divide(car: get_object_or_404) -> list:
-    if len(str(car.serial_number)) > 2:
-        border = len(str(car.serial_number))-2
-        str_serial_number = str(car.serial_number)
-        serial_number_top = int(str_serial_number[:border])
-        serial_number_end = int(str_serial_number[border:])
+    str_number = str(car.serial_number)
+    if len(str_number) > 2:
+        border = len(str_number)-2
+        serial_number_top = int(str_number[:border])
+        serial_number_end = int(str_number[border:])
     else:
         serial_number_top = ""
         serial_number_end = car.serial_number
@@ -59,15 +59,15 @@ def serial_number_divide(car: get_object_or_404) -> list:
 
 class CarEditView(View):
     def get(self, request: HttpRequest, car_id: int):
-        car = get_object_or_404(Car, pk=car_id)
-        serial_number = serial_number_divide(car)
+        dflt_car = get_object_or_404(Car, pk=car_id)
+        serial_number = serial_number_divide(dflt_car)
         serial_number_top = serial_number[0]
         serial_number_end = serial_number[1]
         return render(
             request, 
             "car_edit.html", 
             {
-                "car":car, 
+                "car":dflt_car, 
                 "top":serial_number_top,
                 "end":serial_number_end,
             }

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -59,15 +59,15 @@ def serial_number_divide(car: get_object_or_404) -> list:
 
 class CarEditView(View):
     def get(self, request: HttpRequest, car_id: int):
-        dflt_car = get_object_or_404(Car, pk=car_id)
-        serial_number = serial_number_divide(dflt_car)
-        serial_number_top = serial_number[0]
-        serial_number_end = serial_number[1]
+        car = get_object_or_404(Car, pk=car_id)
+        serial_numbers = serial_number_divide(car)
+        serial_number_top = serial_numbers[0]
+        serial_number_end = serial_numbers[1]
         return render(
             request, 
             "car_edit.html", 
             {
-                "car":dflt_car, 
+                "car":car, 
                 "top":serial_number_top,
                 "end":serial_number_end,
             }

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -73,14 +73,13 @@ class CarEditView(View):
             }
         )
     def post(self, request: HttpRequest, car_id: int):
-        post = get_object_or_404(Car, pk=car_id)
         req = request.POST
         number = int(
             str(req.get("serial_number_top"))
             + str(req.get("serial_number_end"))
         )
         car_trouble = Car(
-            id = post.id,
+            id = car_id,
             place_name = req.get("place_name"),
             class_number = req.get("class_number"),
             kana = req.get("kana"),

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -46,7 +46,7 @@ class CarView(View):
 
 new_car = CarView.as_view()
 
-def serial_number_divide(car: classmethod) -> list:
+def serial_number_divide(car: get_object_or_404) -> list:
     if len(str(car.serial_number)) > 2:
         border = len(str(car.serial_number))-2
         str_serial_number = str(car.serial_number)

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -68,7 +68,7 @@ class CarEditView(View):
             request, 
             "car_edit.html", 
             {
-                "car": car, 
+                "car":car, 
                 "top":serial_number_top,
                 "end":serial_number_end,
             }

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -73,6 +73,23 @@ class CarEditView(View):
                 "end":serial_number_end,
             }
         )
+    def post(self, request: HttpRequest, car_id: int):
+        post = get_object_or_404(Car, pk=car_id)
+        req = request.POST
+        number = int(
+            str(req.get("serial_number_top"))
+            + str(req.get("serial_number_end"))
+        )
+        car_trouble = Car(
+            id = post.id,
+            place_name = req.get("place_name"),
+            class_number = req.get("class_number"),
+            kana = req.get("kana"),
+            serial_number = number,
+            now_mileage = req.get("now_mileage"),
+        )
+        car_trouble.save()
+        return redirect(to="car_list")
 
 
 car_edit = CarEditView.as_view()

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -45,8 +45,7 @@ class CarView(View):
         return redirect(to='car_list')
 
 new_car = CarView.as_view()
-
-def serial_number_divide(car: get_object_or_404) -> list:
+def serial_number_divide(car: Car) -> list:
     str_number = str(car.serial_number)
     if len(str_number) > 2:
         border = len(str_number)-2

--- a/dayrepo/snippets/master_views.py
+++ b/dayrepo/snippets/master_views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render
 from django.views.generic import View
 from django.http import HttpRequest
-from django.shortcuts import redirect
+from django.shortcuts import redirect, get_object_or_404
 from .models import Car
 from .forms import CarForm
 
@@ -45,3 +45,34 @@ class CarView(View):
         return redirect(to='car_list')
 
 new_car = CarView.as_view()
+
+def serial_number_divide(car: object):
+    if len(str(car.serial_number)) > 2:
+        border = len(str(car.serial_number))-2
+        str_serial_number = str(car.serial_number)
+        serial_number_top = int(str_serial_number[:border])
+        serial_number_end = int(str_serial_number[border:])
+    else:
+        serial_number_top = ""
+        serial_number_end = car.serial_number
+    return_list = [serial_number_top,serial_number_end]
+    return return_list
+
+class CarEditView(View):
+    def get(self, request: HttpRequest, car_id: int):
+        car = get_object_or_404(Car, pk=car_id)
+        serial_number = serial_number_divide(car)
+        serial_number_top = serial_number[0]
+        serial_number_end = serial_number[1]
+        return render(
+            request, 
+            "car_edit.html", 
+            {
+                "car": car, 
+                "top":serial_number_top,
+                "end":serial_number_end,
+            }
+        )
+
+
+car_edit = CarEditView.as_view()

--- a/dayrepo/snippets/templates/car_edit.html
+++ b/dayrepo/snippets/templates/car_edit.html
@@ -1,0 +1,28 @@
+<head>
+    {% load static %}
+    <link rel="stylesheet" href='{% static "css/cars.css" %}'>
+</head>
+<h2>車両情報設定</h2>
+<form method="post">
+    <div id="vehicle_number">
+        <p>
+            <label>車両番号:
+                <input type="text"  maxlength="4" id="place_name" name="place_name" placeholder="札幌" value={{car.place_name}} required>
+                <input type="number" maxlength="3" id="class_number" name="class_number" placeholder="100" value={{car.class_number}} required>
+                <input type="text" maxlength="1" id="kana" name="kana" placeholder="あ" value={{car.kana}} required>
+                <input type="number" maxlength="2" id="serial_number_top" name="serial_number_top" value={{top}} placeholder="88">
+                -
+                <input type="number" maxlength="2" id="serial_number_end" name="serial_number_end" value={{end}} placeholder="88" required>
+            </label>
+        </p>
+    </div>
+    <p>
+        <label for="now_mileage">走行距離:
+            <input type="number" id="now_mileage" name="now_mileage" placeholder="車両の初期メーター値km" value={{car.now_mileage}} required>    
+        </label>
+    </p>
+    {% csrf_token %}
+    <button type="submit" id="car_post">
+        車両追加
+    </button>
+</form>

--- a/dayrepo/snippets/templates/car_edit.html
+++ b/dayrepo/snippets/templates/car_edit.html
@@ -23,6 +23,6 @@
     </p>
     {% csrf_token %}
     <button type="submit" id="car_post">
-        車両追加
+        編集実行
     </button>
 </form>

--- a/dayrepo/snippets/templates/car_list.html
+++ b/dayrepo/snippets/templates/car_list.html
@@ -11,5 +11,6 @@
     </p>
     <p> 現在のメーター値 <strong>{{ car.now_mileage }}</strong> km </p>
 </div>
+<button onclick="location.href='{% url 'car_edit' car.id %}'">車両編集</button>
 <hr>
 {% endfor %}

--- a/dayrepo/snippets/urls.py
+++ b/dayrepo/snippets/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path("excel/<int:snippet_pk>/", views.excelfile_download,name="excelfile_download"),
     path("cars/", master_views.car_list,name="car_list"),
     path("new/car/", master_views.new_car,name="new_car"),
+    path("edit/car/<int:car_id>/", master_views.car_edit,name="car_edit"),
 ]

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -139,6 +139,7 @@ class SnippetView(View):
         form_process_count = len(req.getlist("via_point"))
         for i in range(form_process_count):
             process = Process(
+                id = snippet.id*10 + i,
                 snippet_id=snippet,
                 start_time=req.getlist("start_time")[i + 1],
                 end_time=req.getlist("end_time")[i + 1],
@@ -291,15 +292,14 @@ class SnippetEditView(View):
             trouble_cause=req.get("trouble_cause"),
             trouble_support=req.get("trouble_support"),
         )
-        post_trouble.delete()
         duties_trouble.save()
 
         # 工程テーブルフォーム保存
         form_process_count = len(req.getlist("via_point"))
         for i in range(form_process_count):
             process = Process(
-                id=post_process[i].id,
-                snippet_id=post_process[i].snippet_id,
+                id= snippet.id*10 + i,
+                snippet_id=snippet,
                 start_time=req.getlist("start_time")[i + 1],
                 end_time=req.getlist("end_time")[i + 1],
                 start_point=req.getlist("start_point")[i + 1],
@@ -316,7 +316,6 @@ class SnippetEditView(View):
                 process.is_load_situation = True
             else:
                 process.is_load_situation = False
-            post_process[i].delete()
             process.save()
         post_snippet = snippet
         # トップ画面へ

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -239,11 +239,6 @@ class SnippetEditView(View):
 
     def post(self, request: HttpRequest, snippet_id: int):
         req = request.POST
-        post_snippet = get_object_or_404(Snippet, pk=snippet_id)
-        post_trouble = get_object_or_404(DutiesTrouble, snippet_id=snippet_id)
-        post_process = get_list_or_404(Process, snippet_id=snippet_id)
-        checklist_id = post_snippet.checklist_id
-        # スニペットフォーム保存
         # checklists_id挿入のための
         # モデルデータ作成
         gasoline = req.get("gasoline_amount")
@@ -253,6 +248,8 @@ class SnippetEditView(View):
         if oil == "":
             oil = 0.0
 
+        post_snippet = get_object_or_404(Snippet, pk=snippet_id)
+        checklist_id = post_snippet.checklist_id
         snippet = Snippet(
             id=post_snippet.pk,
             checklist_id=checklist_id,
@@ -284,6 +281,7 @@ class SnippetEditView(View):
         snippet.save()
 
         # 業務トラブルフォーム保存
+        post_trouble = get_object_or_404(DutiesTrouble, snippet_id=snippet_id)
         duties_trouble = DutiesTrouble(
             id=post_trouble.id,
             snippet_id=post_trouble.snippet_id,
@@ -294,6 +292,7 @@ class SnippetEditView(View):
         duties_trouble.save()
 
         # 工程テーブルフォーム保存
+        post_process = get_list_or_404(Process, snippet_id=snippet_id)
         def_count = len(post_process)
         for i in range(def_count):
             process = Process(

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -41,7 +41,7 @@ def get_employee(request):
 
 
 class SnippetListView(View):
-    def get(self, request):
+    def get(self, request: HttpRequest):
         # 記録してある投稿の全データを投稿時間を元にソートして表示
         # snippets は存在する時点で提出済みとみなす
         snippets = Snippet.objects.all().order_by("-create_at")
@@ -66,7 +66,7 @@ snippet_list = SnippetListView.as_view()
 # snippet画面の表示/POST後処理
 class SnippetView(View):
     # 新規入力画面へ
-    def get(self, request, checklist_id):
+    def get(self, request: HttpRequest, checklist_id: int):
         # 投稿ボタンで投稿ページへ
         return render(
             request,
@@ -81,7 +81,7 @@ class SnippetView(View):
         )
 
     # 投稿機能
-    def post(self, request, checklist_id):
+    def post(self, request: HttpRequest, checklist_id: int):
         req = request.POST
         checklist = Checklist.objects.get(pk=checklist_id)
         # スニペットフォーム保存
@@ -199,12 +199,12 @@ checklist_post = ChecklistView.as_view()
 
 
 class ChecklistEditView(View):
-    def get(self, request, checklist_id):
+    def get(self, request: HttpRequest, checklist_id: int):
         checklist = get_object_or_404(Checklist, pk=checklist_id)
         edit_form = ChecklistForm(instance=checklist)
         return render(request, "checklist_edit.html", {"form": edit_form})
 
-    def post(self, request, checklist_id):
+    def post(self, request: HttpRequest, checklist_id: int):
         post = get_object_or_404(Checklist, pk=checklist_id)
         form = ChecklistForm(request.POST, instance=post)
         form.save()
@@ -214,7 +214,7 @@ checklist_edit = ChecklistEditView.as_view()
 
 
 class SnippetEditView(View):
-    def get(self, request, snippet_id):
+    def get(self, request: HttpRequest, snippet_id: int):
         post_snippet = get_object_or_404(Snippet, pk=snippet_id)
         post_trouble = get_object_or_404(DutiesTrouble, snippet_id=snippet_id)
         post_process = get_list_or_404(Process, snippet_id=snippet_id)
@@ -237,7 +237,7 @@ class SnippetEditView(View):
             },
         )
 
-    def post(self, request, snippet_id):
+    def post(self, request: HttpRequest, snippet_id: int):
         req = request.POST
         post_snippet = get_object_or_404(Snippet, pk=snippet_id)
         post_trouble = get_object_or_404(DutiesTrouble, snippet_id=snippet_id)

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -296,7 +296,7 @@ class SnippetEditView(View):
         def_count = len(post_process)
         for i in range(def_count):
             process = Process(
-                id= post_process[i].id,
+                id=post_process[i].id,
                 snippet_id=snippet,
                 start_time=req.getlist("start_time")[i + 1],
                 end_time=req.getlist("end_time")[i + 1],

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -294,9 +294,7 @@ class SnippetEditView(View):
         duties_trouble.save()
 
         # 工程テーブルフォーム保存
-        print("あああああああ",len(post_process))
         def_proc_count = len(post_process)
-        add_proc_count = len(req.getlist("via_point")) - def_proc_count
         for i in range(def_proc_count):
             process = Process(
                 id= post_process[i].id,
@@ -318,7 +316,8 @@ class SnippetEditView(View):
             else:
                 process.is_load_situation = False
             process.save()
-        if def_proc_count == 0:
+        add_proc_count = len(req.getlist("via_point")) - def_proc_count
+        if add_proc_count == 0:
             return redirect(to="snippet_list")
         for i in range(add_proc_count):
             process = Process(

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -294,8 +294,8 @@ class SnippetEditView(View):
         duties_trouble.save()
 
         # 工程テーブルフォーム保存
-        def_proc_count = len(post_process)
-        for i in range(def_proc_count):
+        def_count = len(post_process)
+        for i in range(def_count):
             process = Process(
                 id= post_process[i].id,
                 snippet_id=snippet,
@@ -316,23 +316,23 @@ class SnippetEditView(View):
             else:
                 process.is_load_situation = False
             process.save()
-        add_proc_count = len(req.getlist("via_point")) - def_proc_count
-        if add_proc_count == 0:
+        add_count = len(req.getlist("via_point")) - def_count
+        if add_count == 0:
             return redirect(to="snippet_list")
-        for i in range(add_proc_count):
+        for i in range(add_count):
             process = Process(
                 snippet_id=snippet,
-                start_time=req.getlist("start_time")[def_proc_count + i + 1],
-                end_time=req.getlist("end_time")[def_proc_count + i + 1],
-                start_point=req.getlist("start_point")[def_proc_count + i + 1],
-                end_point=req.getlist("end_point")[def_proc_count + i + 1],
-                via_point=req.getlist("via_point")[def_proc_count + i],
-                client=req.getlist("client")[def_proc_count + i],
-                goods=req.getlist("goods")[def_proc_count + i],
-                load_situation=req.getlist("load_situation")[def_proc_count + i],
-                load_mileage=req.getlist("load_mileage")[def_proc_count + i],
-                hollow_mileage=req.getlist("hollow_mileage")[def_proc_count + i],
-                is_load_situation=req.getlist("is_load_situation")[def_proc_count + i],
+                start_time=req.getlist("start_time")[def_count + i + 1],
+                end_time=req.getlist("end_time")[def_count + i + 1],
+                start_point=req.getlist("start_point")[def_count + i + 1],
+                end_point=req.getlist("end_point")[def_count + i + 1],
+                via_point=req.getlist("via_point")[def_count + i],
+                client=req.getlist("client")[def_count + i],
+                goods=req.getlist("goods")[def_count + i],
+                load_situation=req.getlist("load_situation")[def_count + i],
+                load_mileage=req.getlist("load_mileage")[def_count + i],
+                hollow_mileage=req.getlist("hollow_mileage")[def_count + i],
+                is_load_situation=req.getlist("is_load_situation")[def_count + i],
             )
             if process.is_load_situation == "on":
                 process.is_load_situation = True

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -139,7 +139,6 @@ class SnippetView(View):
         form_process_count = len(req.getlist("via_point"))
         for i in range(form_process_count):
             process = Process(
-                id = snippet.id*10 + i,
                 snippet_id=snippet,
                 start_time=req.getlist("start_time")[i + 1],
                 end_time=req.getlist("end_time")[i + 1],
@@ -295,10 +294,12 @@ class SnippetEditView(View):
         duties_trouble.save()
 
         # 工程テーブルフォーム保存
-        form_process_count = len(req.getlist("via_point"))
-        for i in range(form_process_count):
+        print("あああああああ",len(post_process))
+        def_proc_count = len(post_process)
+        add_proc_count = len(req.getlist("via_point")) - def_proc_count
+        for i in range(def_proc_count):
             process = Process(
-                id= snippet.id*10 + i,
+                id= post_process[i].id,
                 snippet_id=snippet,
                 start_time=req.getlist("start_time")[i + 1],
                 end_time=req.getlist("end_time")[i + 1],
@@ -317,7 +318,28 @@ class SnippetEditView(View):
             else:
                 process.is_load_situation = False
             process.save()
-        post_snippet = snippet
+        if def_proc_count == 0:
+            return redirect(to="snippet_list")
+        for i in range(add_proc_count):
+            process = Process(
+                snippet_id=snippet,
+                start_time=req.getlist("start_time")[def_proc_count + i + 1],
+                end_time=req.getlist("end_time")[def_proc_count + i + 1],
+                start_point=req.getlist("start_point")[def_proc_count + i + 1],
+                end_point=req.getlist("end_point")[def_proc_count + i + 1],
+                via_point=req.getlist("via_point")[def_proc_count + i],
+                client=req.getlist("client")[def_proc_count + i],
+                goods=req.getlist("goods")[def_proc_count + i],
+                load_situation=req.getlist("load_situation")[def_proc_count + i],
+                load_mileage=req.getlist("load_mileage")[def_proc_count + i],
+                hollow_mileage=req.getlist("hollow_mileage")[def_proc_count + i],
+                is_load_situation=req.getlist("is_load_situation")[def_proc_count + i],
+            )
+            if process.is_load_situation == "on":
+                process.is_load_situation = True
+            else:
+                process.is_load_situation = False
+            process.save()
         # トップ画面へ
         return redirect(to="snippet_list")
 

--- a/dayrepo/snippets/views.py
+++ b/dayrepo/snippets/views.py
@@ -249,10 +249,9 @@ class SnippetEditView(View):
             oil = 0.0
 
         post_snippet = get_object_or_404(Snippet, pk=snippet_id)
-        checklist_id = post_snippet.checklist_id
         snippet = Snippet(
             id=post_snippet.pk,
-            checklist_id=checklist_id,
+            checklist_id=post_snippet.checklist_id,
             # 末尾の [0] について
             # 入力項目のうち同一名のデータは、
             # request.POST に配列で記録され、


### PR DESCRIPTION
# 概要
登録済み車両情報の編集機能を追加します。
見積もりなどの[issue](https://github.com/bob-g12/dayrepo-for-transportation/issues/59)
## snippet編集機能の修正(追加工程)
- 編集の際に既存データを削除する必要がないためdelete処理を削除
- 編集により工程フォームを追加した際に登録する処理がなく、編集も追加と同じ処理で行えるように変更
    - idが連番になるようにすることでsnippetのidと順番から工程フォームのidを指定することが可能にした。 
